### PR TITLE
Improve support for hidden fields in webform.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: php
 sudo: false
 
 php:
-  - 5.3
   - 5.4
+  - 7.0
 
 mysql:
   database: drupal

--- a/modules/webform/form_builder_webform.classes.inc
+++ b/modules/webform/form_builder_webform.classes.inc
@@ -283,3 +283,35 @@ class FormBuilderWebformPropertyOptions extends FormBuilderWebformProperty {
     $form_state['values']['options'] = $options;
   }
 }
+
+/**
+ * Special behaviour for hidden elements.
+ */
+class FormBuilderWebformHiddenElement extends FormBuilderWebformElement {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function configurationForm($form, &$form_state) {
+    $form = parent::configurationForm($form, $form_state);
+
+    // Configure default value as textarea to allow for more data.
+    $form['default_value']['#type'] = 'textarea';
+
+    // Add configuration for $component['extra']['hidden_type'].
+    $display['#form_builder']['property_group'] = 'display';
+    $e = webform_component_invoke('hidden', 'edit', $this->element['#webform_component']);
+    $form['hidden_type'] = $e['display']['hidden_type'] + $display;
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function configurationSubmit(&$form, &$form_state) {
+    parent::configurationSubmit($form, $form_state);
+    $this->element['#webform_component']['extra']['hidden_type'] = $form_state['values']['extra']['hidden_type'];
+  }
+
+}

--- a/modules/webform/form_builder_webform.components.inc
+++ b/modules/webform/form_builder_webform.components.inc
@@ -388,9 +388,12 @@ function _form_builder_webform_form_builder_types_hidden() {
   $fields['hidden'] = array(
     'title' => t('Hidden'),
     'weight' => 8,
+    'class' => 'FormBuilderWebformHiddenElement',
   );
   $component['name'] = t('New hidden');
-  $fields['hidden']['default'] = _form_builder_webform_default('hidden', array(), $component);
+  $fields['hidden']['default'] = _form_builder_webform_default('hidden', array(
+    'hidden_type' => 'hidden',
+  ), $component);
 
   return $fields;
 }
@@ -403,13 +406,18 @@ function _form_builder_webform_form_builder_preview_alter_hidden($form_element) 
   $form_element['#type'] = 'markup';
   $form_element['#form_builder']['element_type'] = 'markup';
   unset($form_element['#theme']);
-
-  // Add the 'webform_element' theme wrapper at the beginning, where it would
-  // normally be.
-  array_unshift($form_element['#theme_wrappers'], 'webform_element');
+  $c = $form_element['#webform_component'];
+  if ($c['extra']['hidden_type'] == 'value') {
+    array_unshift($form_element['#theme_wrappers'], 'webform_element');
+  }
+  else {
+    unset($form_element['#wrapper_attributes']);
+  }
 
   // Display the title of the hidden field as regular markup.
-  $form_element['#children'] = t('@title - <em>hidden field</em>', array('@title' => $form_element['#webform_component']['name']));
+  $v['@title'] = $c['name'];
+  $v['@type'] = $c['extra']['hidden_type'] == 'value' ? 'secure' : 'insecure - editable by JavaScript';
+  $form_element['#children'] = t('@title - <em>hidden field (@type)</em>', $v);
 
   return $form_element;
 }


### PR DESCRIPTION
- Textarea for entering values to allow more than 128 chars.
- Allow configuration of hidden_type in form_builder.
- Proper preview for hidden_type='hidden' (previously the preview was
  empty).